### PR TITLE
Fix Python2.7 builds and simplify Travis setup

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,8 @@ environment:
       CONDA_INSTALL_LOCN: "C:\\Miniconda35-x64"
     - PYTHON_VERSION: "3.6"
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
+    - PYTHON_VERSION: "3.7"
+      CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
 
 platform:
   - x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,12 @@ python:
 matrix:
   include:
     - os: osx
-      osx_image: xcode11
-      language: shell
-
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew update;
-      brew unlink pyenv;
-      brew install pyenv;
-      pyenv install $TRAVIS_PYTHON_VERSION;
-      pyenv global $TRAVIS_PYTHON_VERSION;
-      pip install --upgrade pip;
-    fi
+      language: generic
+      before_install:
+        brew update;
+        brew install python3;
+        pip3 install --upgrade pip;
+        pip3 install virtualenv;
 
 install:
   - virtualenv /tmp/test-env

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ language: python
 os:
   - linux
   - osx
+  - windows
 
 python:
   - "2.7"
   - "3.5"
   - "3.6"
-  - "2.7"
+  - "3.7"
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,50 +1,27 @@
 language: python
 
-dist: xenial
+os:
+  - linux
+  - osx
 
-matrix:
-  include:
-    - python: 2.7
-    - python: 3.5
-    - python: 3.6
-    - os: osx
-      language: generic
-      only: master 
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
+  - "2.7"
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew update;
-      brew install wget;
-      MINICONDA_LCN_2="https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh";
-      MINICONDA_LCN_3="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh";
-    else
-      sudo apt-get update;
-      MINICONDA_LCN_2="https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh";
-      MINICONDA_LCN_3="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh";
-    fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
 
 install:
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget $MINICONDA_LCN_2 -O miniconda.sh;
-    else
-      wget $MINICONDA_LCN_3 -O miniconda.sh;
-    fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes true 
-  - conda update --all
-  - conda config --set show_channel_urls yes
-  - conda config --prepend channels conda-forge
-  - conda info -a
-
-  # Take these dependencies since their installation order can cause problems at times :/
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-  - source activate test-environment
-  - pip install codecov coverage
+  - virtualenv /tmp/test-env
+  - /tmp/test-env/bin/python -VV
+  - /tmp/test-env/bin/pip install codecov coverage
+  - /tmp/test-env/bin/python setup.py install
 
 script:
-  - python setup.py test
+  - /tmp/test-env/bin/python setup.py test
 
 after_success:
   - codecov 
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 os:
   - linux
   - osx
-  - windows
 
 python:
   - "2.7"
@@ -11,8 +10,20 @@ python:
   - "3.6"
   - "3.7"
 
+matrix:
+  include:
+    - os: osx
+      language: generic
+
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew update;
+      brew unlink pyenv;
+      brew install pyenv;
+      pyenv install $TRAVIS_PYTHON_VERSION;
+      pyenv global $TRAVIS_PYTHON_VERSION;
+      pip install --upgrade pip;
+    fi
 
 install:
   - virtualenv /tmp/test-env

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 os:
   - linux
-  - osx
 
 python:
   - "2.7"
@@ -13,7 +12,8 @@ python:
 matrix:
   include:
     - os: osx
-      language: generic
+      osx_image: xcode11
+      language: shell
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ python:
 
 matrix:
   include:
-    - os: osx
+    - name: "Python 3"
+      os: osx
       language: generic
       before_install:
         brew update;

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,17 @@ CLASSIFIERS = [
 ]
 
 ENTRY_POINTS = {'console_scripts': ['pyjob = pyjob.__main__:main']}
+SETUP_REQUIRES = ['pytest-runner ==5.1', 'configparser>=3.5;python_version<"3"']
+TESTS_REQUIRE = [
+    'codecov ==2.0.15',
+    'coverage ==4.5.4',
+    'importlib-metadata ==0.20;python_version<"3"',
+    'pluggy ==0.12;python_version<"3"',
+    'pytest ==4.6.5',
+    'pytest-cov ==2.7.1',
+    'pytest-pep8 ==1.0.6',
+    'pytest-helpers-namespace ==2019.1.8',
+]
 
 setup(
     author=AUTHOR,
@@ -77,7 +88,7 @@ setup(
     package_dir={PACKAGE_NAME: PACKAGE_DIR},
     classifiers=CLASSIFIERS,
     install_requires=dependencies(),
-    setup_requires=['pytest-runner'],
-    tests_require=['codecov', 'coverage', 'pytest', 'pytest-cov', 'pytest-pep8', 'pytest-helpers-namespace'],
+    setup_requires=SETUP_REQUIRES,
+    tests_require=TESTS_REQUIRE,
     zip_safe=False,
 )


### PR DESCRIPTION
Travis and Python dependencies are messed up. This fixes it for Python2.7 builds and simplifies the Travis file to avoid creating a Conda environment